### PR TITLE
Install header files to $DESTDIR/share/lily/

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,4 +29,4 @@ install(FILES lily_api_alloc.h
               lily_api_msgbuf.h
               lily_api_value.h
               lily_int_opcode.h
-        DESTINATION "lily")
+        DESTINATION "share/lily")


### PR DESCRIPTION
By default `make install` will put everything under `/usr/`. Pre-change DESTINATION leads to `/usr/lily/*.h` which isn't great - it should probably be in `/usr/share/lily/*.h` instead.