### PR TITLE
Install header files to $DESTDIR/include/lily/

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,4 +29,4 @@ install(FILES lily_api_alloc.h
               lily_api_msgbuf.h
               lily_api_value.h
               lily_int_opcode.h
-        DESTINATION "lily")
+        DESTINATION "include/lily")


### PR DESCRIPTION
By default `make install` will put everything under `/usr/local/`. Pre-change DESTINATION leads to `/usr/local/lily/*.h` which isn't great - it should be `/usr/local/include/lily/*.h` instead.